### PR TITLE
Contrôler les nom des rôles avant validation

### DIFF
--- a/sql/sql_roles.sql
+++ b/sql/sql_roles.sql
@@ -1,2 +1,9 @@
 USE Pitson;
 GO
+
+CREATE ROLE ResponsableApplication;
+CREATE ROLE ResponsableAtelier;
+CREATE ROLE ResponsablePresse;
+CREATE ROLE Controleur;
+CREATE ROLE Magasinier;
+CREATE ROLE ResponsableQualite;


### PR DESCRIPTION
Règles de nommage : Majuscule en début de mot, pas d'accent.